### PR TITLE
Incoming and outgoing ports need to be switched for mail setup.

### DIFF
--- a/docs/dxp/7.x/en/installation-and-upgrades/setting-up-liferay-dxp/configuring-mail/alternative-email-configuration-methods.md
+++ b/docs/dxp/7.x/en/installation-and-upgrades/setting-up-liferay-dxp/configuring-mail/alternative-email-configuration-methods.md
@@ -14,12 +14,12 @@ To configure the mail session offline or before deploying DXP:
     mail.session.mail=false
     mail.session.mail.pop3.host=pop.gmail.com
     mail.session.mail.pop3.password=*******
-    mail.session.mail.pop3.port=465
+    mail.session.mail.pop3.port=110
     mail.session.mail.pop3.user=joe.bloggs
     mail.session.mail.smtp.auth=true
     mail.session.mail.smtp.host=smtp.gmail.com
     mail.session.mail.smtp.password=*******
-    mail.session.mail.smtp.port=110
+    mail.session.mail.smtp.port=465
     mail.session.mail.smtp.user=joe.bloggs
     mail.session.mail.store.protocol=pop3
     mail.session.mail.transport.protocol=smtp

--- a/docs/dxp/7.x/en/installation-and-upgrades/setting-up-liferay-dxp/configuring-mail/connecting-to-a-mail-server.md
+++ b/docs/dxp/7.x/en/installation-and-upgrades/setting-up-liferay-dxp/configuring-mail/connecting-to-a-mail-server.md
@@ -15,12 +15,12 @@ Follow these steps to configure the mail session from the Control Panel:
 1. Enter your values for the [following fields](#mail-configuration-reference):
 
     * **Incoming POP Server:** pop.gmail.com
-    * **Incoming Port:** 465
+    * **Incoming Port:** 110
     * **Use a Secure Network Connection:** Flagged
     * **User Name:** joe.bloggs
     * **Password:** *****
     * **Outgoing SMTP Server:** smtp.gmail.com
-    * **Outgoing Port:** 110
+    * **Outgoing Port:** 465
     * **Use a Secure Network Connection:** Flagged
     * **User Name:** joe.bloggs
     * **Password:** *****


### PR DESCRIPTION
Hey team, I noticed while trying to configure a mail server that the ports are swapped in the documentation. This change fixes that. Let me know if you have any questions. 