### PR TITLE
LRDOCS-8814 Fix and improve S1J6 code

### DIFF
--- a/docs/dxp/7.x/en/liferay-internals/extending-liferay/overriding-osgi-services/creating-a-custom-osgi-service/resources/liferay-s1j6.zip/s1j6-baker-impl/src/main/java/com/acme/s1j6/baker/internal/S1J6BakerImpl.java
+++ b/docs/dxp/7.x/en/liferay-internals/extending-liferay/overriding-osgi-services/creating-a-custom-osgi-service/resources/liferay-s1j6.zip/s1j6-baker-impl/src/main/java/com/acme/s1j6/baker/internal/S1J6BakerImpl.java
@@ -15,8 +15,7 @@ public class S1J6BakerImpl implements S1J6 {
 	}
 
 	@Reference(
-		target = "(component.name=com.acme.s1j6.able.internal.S1J6AbleImpl)",
-		unbind = "-"
+		target = "(component.name=com.acme.s1j6.able.internal.S1J6AbleImpl)"
 	)
 	private S1J6 _s1j6;
 

--- a/docs/dxp/7.x/en/liferay-internals/extending-liferay/overriding-osgi-services/creating-a-custom-osgi-service/resources/liferay-s1j6.zip/s1j6-baker-impl/src/main/java/com/acme/s1j6/baker/internal/S1J6BakerImpl.java
+++ b/docs/dxp/7.x/en/liferay-internals/extending-liferay/overriding-osgi-services/creating-a-custom-osgi-service/resources/liferay-s1j6.zip/s1j6-baker-impl/src/main/java/com/acme/s1j6/baker/internal/S1J6BakerImpl.java
@@ -15,7 +15,7 @@ public class S1J6BakerImpl implements S1J6 {
 	}
 
 	@Reference(
-		target = "(component.name=com.acme.s1j6.internal.S1J6Impl)",
+		target = "(component.name=com.acme.s1j6.able.internal.S1J6AbleImpl)",
 		unbind = "-"
 	)
 	private S1J6 _s1j6;

--- a/docs/dxp/7.x/en/liferay-internals/extending-liferay/overriding-osgi-services/creating-a-custom-osgi-service/resources/liferay-s1j6.zip/s1j6-web/src/main/java/com/acme/s1j6/web/internal/portlet/S1J6Portlet.java
+++ b/docs/dxp/7.x/en/liferay-internals/extending-liferay/overriding-osgi-services/creating-a-custom-osgi-service/resources/liferay-s1j6.zip/s1j6-web/src/main/java/com/acme/s1j6/web/internal/portlet/S1J6Portlet.java
@@ -33,7 +33,7 @@ public class S1J6Portlet extends GenericPortlet {
 		printWriter.println(_s1J6.doSomething());
 	}
 
-	@Reference(unbind = "-")
+	@Reference
 	private S1J6 _s1J6;
 
 }


### PR DESCRIPTION
As @mtokudome pointed out, the Reference target for S1J6BakerImpl's _s1j6 field needed to be changed to S1J6AbleImpl...

`target = "(component.name=com.acme.s1j6.able.internal.S1J6AbleImpl)"`

As for improvements, the example tested fine after removing the `unbind = "0"` Reference attibs.

cc @jamesagarcia
