### PR TITLE
LRDOCS-8871 - Fixed Installation Overview link

### DIFF
--- a/docs/commerce/2.x/en/installation-and-upgrades/installing-commerce-2.1-and-below/using-the-liferay-commerce-tomcat-bundle.md
+++ b/docs/commerce/2.x/en/installation-and-upgrades/installing-commerce-2.1-and-below/using-the-liferay-commerce-tomcat-bundle.md
@@ -27,6 +27,6 @@ To use the Liferay Commerce bundle, follow these steps:
 
 ## Additional Information
 
-* [Installation Overview](./installation-overview.md)
+* [Installation Overview](../installation-overview.md)
 * [Installing Liferay DXP](https://learn.liferay.com/dxp/7.x/en/installation-and-upgrades/installing-liferay/installing-a-liferay-tomcat-bundle.html)
 * [Liferay Commerce 3.0 Compatibility Matrix](https://help.liferay.com/hc/en-us/articles/360049238151)


### PR DESCRIPTION
The 1st link in the Installation Overview is currently returning a 404.  Updated link based on the 'Installation Overview' link on the other 2 articles that cover 2.1 installation topics:  
* Using the Liferay Commerce Docker Image 
* Deploying Liferay Commerce to an Existing Liferay Installation