### PR TITLE
Fix location of frontend-token-definition.json

### DIFF
--- a/docs/dxp/latest/en/site-building/site-appearance/style-books/developer-guide/style-book-token-definitions.md
+++ b/docs/dxp/latest/en/site-building/site-appearance/style-books/developer-guide/style-book-token-definitions.md
@@ -124,7 +124,7 @@ Here is an example list of tokens within a token set:
 
 ## Matching CSS Variables to Style Book Tokens
 
-The `frontend-token-definition.json` file containing your token definition must be in the root level of your theme module folder. Every token defined in your token definition must represent a style (color, spacing, font, etc.) in the CSS of your theme.
+The `frontend-token-definition.json` file containing your token definition must be in the src/WEB-INF folder of your theme module folder. Every token defined in your token definition must represent a style (color, spacing, font, etc.) in the CSS of your theme.
 
 All styles that your tokens represent must be coded as CSS variables. For example, take this definition of a token (giving an option to configure a font):
 


### PR DESCRIPTION
The current text is really misleading, we thought that the file should be placed in the root folder of our theme, which is /our-theme and not /our-theme/src/WEB-INF. This change makes it more clear to developers where the file has to be placed.