### PR TITLE
LRDOCS-9534 ConfigurationScreen code

### DIFF
--- a/docs/dxp/latest/en/developing-applications/core-frameworks/configuration-framework/completely-custom-configuration/resources/liferay-u2g5.zip/u2g5-web/bnd.bnd
+++ b/docs/dxp/latest/en/developing-applications/core-frameworks/configuration-framework/completely-custom-configuration/resources/liferay-u2g5.zip/u2g5-web/bnd.bnd
@@ -1,0 +1,4 @@
+Bundle-Name: Acme U2G5 Web
+Bundle-SymbolicName: com.acme.u2g5.web
+Bundle-Version: 1.0.0
+Web-ContextPath: /u2g5-web

--- a/docs/dxp/latest/en/developing-applications/core-frameworks/configuration-framework/completely-custom-configuration/resources/liferay-u2g5.zip/u2g5-web/build.gradle
+++ b/docs/dxp/latest/en/developing-applications/core-frameworks/configuration-framework/completely-custom-configuration/resources/liferay-u2g5.zip/u2g5-web/build.gradle
@@ -1,0 +1,3 @@
+dependencies {
+	compileOnly group: "com.liferay.portal", name: "release.portal.api"
+}

--- a/docs/dxp/latest/en/developing-applications/core-frameworks/configuration-framework/completely-custom-configuration/resources/liferay-u2g5.zip/u2g5-web/src/main/java/com/acme/u2g5/web/internal/configuration/U2G5WebConfiguration.java
+++ b/docs/dxp/latest/en/developing-applications/core-frameworks/configuration-framework/completely-custom-configuration/resources/liferay-u2g5.zip/u2g5-web/src/main/java/com/acme/u2g5/web/internal/configuration/U2G5WebConfiguration.java
@@ -1,0 +1,26 @@
+package com.acme.u2g5.web.internal.configuration;
+
+import aQute.bnd.annotation.metatype.Meta;
+
+import com.liferay.portal.configuration.metatype.annotations.ExtendedObjectClassDefinition;
+
+@ExtendedObjectClassDefinition(
+	category = "u2g5", generateUI = false,
+	scope = ExtendedObjectClassDefinition.Scope.SYSTEM
+)
+@Meta.OCD(
+	id = "com.acme.u2g5.web.internal.configuration.U2G5WebConfiguration",
+	localization = "content/Language", name = "u2g5-configuration-name"
+)
+public interface U2G5WebConfiguration {
+
+	@Meta.AD(deflt = "blue", required = false)
+	public String fontColor();
+
+	@Meta.AD(deflt = "serif", required = false)
+	public String fontFamily();
+
+	@Meta.AD(deflt = "16", required = false)
+	public int fontSize();
+
+}

--- a/docs/dxp/latest/en/developing-applications/core-frameworks/configuration-framework/completely-custom-configuration/resources/liferay-u2g5.zip/u2g5-web/src/main/java/com/acme/u2g5/web/internal/configuration/U2G5WebConfiguration.java
+++ b/docs/dxp/latest/en/developing-applications/core-frameworks/configuration-framework/completely-custom-configuration/resources/liferay-u2g5.zip/u2g5-web/src/main/java/com/acme/u2g5/web/internal/configuration/U2G5WebConfiguration.java
@@ -10,7 +10,7 @@ import com.liferay.portal.configuration.metatype.annotations.ExtendedObjectClass
 )
 @Meta.OCD(
 	id = "com.acme.u2g5.web.internal.configuration.U2G5WebConfiguration",
-	localization = "content/Language", name = "u2g5-configuration-name"
+	localization = "content/Language", name = "u2g5-configuration"
 )
 public interface U2G5WebConfiguration {
 

--- a/docs/dxp/latest/en/developing-applications/core-frameworks/configuration-framework/completely-custom-configuration/resources/liferay-u2g5.zip/u2g5-web/src/main/java/com/acme/u2g5/web/internal/configuration/admin/display/U2G5ConfigurationScreen.java
+++ b/docs/dxp/latest/en/developing-applications/core-frameworks/configuration-framework/completely-custom-configuration/resources/liferay-u2g5.zip/u2g5-web/src/main/java/com/acme/u2g5/web/internal/configuration/admin/display/U2G5ConfigurationScreen.java
@@ -1,0 +1,73 @@
+package com.acme.u2g5.web.internal.configuration.admin.display;
+
+import com.acme.u2g5.web.internal.configuration.U2G5WebConfiguration;
+
+import com.liferay.configuration.admin.display.ConfigurationScreen;
+import com.liferay.portal.kernel.module.configuration.ConfigurationProvider;
+
+import java.io.IOException;
+
+import java.util.Locale;
+
+import javax.servlet.RequestDispatcher;
+import javax.servlet.ServletContext;
+import javax.servlet.http.HttpServletRequest;
+import javax.servlet.http.HttpServletResponse;
+
+import org.osgi.service.component.annotations.Component;
+import org.osgi.service.component.annotations.Reference;
+
+@Component(service = ConfigurationScreen.class)
+public class U2G5ConfigurationScreen implements ConfigurationScreen {
+
+	@Override
+	public String getCategoryKey() {
+		return "third-party";
+	}
+
+	@Override
+	public String getKey() {
+		return "u2g5-configuration-name";
+	}
+
+	@Override
+	public String getName(Locale locale) {
+		return "U2G5 Custom Configuration";
+	}
+
+	@Override
+	public String getScope() {
+		return "system";
+	}
+
+	@Override
+	public void render(
+			HttpServletRequest httpServletRequest,
+			HttpServletResponse httpServletResponse)
+		throws IOException {
+
+		try {
+			httpServletRequest.setAttribute(
+				U2G5WebConfiguration.class.getName(),
+				_configurationProvider.getSystemConfiguration(
+					U2G5WebConfiguration.class));
+
+			RequestDispatcher requestDispatcher =
+				_servletContext.getRequestDispatcher("/u2g5.jsp");
+
+			requestDispatcher.include(httpServletRequest, httpServletResponse);
+		}
+		catch (Exception exception) {
+			throw new IOException("Unable to render", exception);
+		}
+	}
+
+	@Reference
+	private ConfigurationProvider _configurationProvider;
+
+	@Reference(
+		target = "(osgi.web.symbolicname=com.acme.u2g5.web)", unbind = "-"
+	)
+	private ServletContext _servletContext;
+
+}

--- a/docs/dxp/latest/en/developing-applications/core-frameworks/configuration-framework/completely-custom-configuration/resources/liferay-u2g5.zip/u2g5-web/src/main/java/com/acme/u2g5/web/internal/configuration/admin/display/U2G5ConfigurationScreen.java
+++ b/docs/dxp/latest/en/developing-applications/core-frameworks/configuration-framework/completely-custom-configuration/resources/liferay-u2g5.zip/u2g5-web/src/main/java/com/acme/u2g5/web/internal/configuration/admin/display/U2G5ConfigurationScreen.java
@@ -3,7 +3,9 @@ package com.acme.u2g5.web.internal.configuration.admin.display;
 import com.acme.u2g5.web.internal.configuration.U2G5WebConfiguration;
 
 import com.liferay.configuration.admin.display.ConfigurationScreen;
+import com.liferay.portal.kernel.language.LanguageUtil;
 import com.liferay.portal.kernel.module.configuration.ConfigurationProvider;
+import com.liferay.portal.kernel.util.ResourceBundleUtil;
 
 import java.io.IOException;
 
@@ -32,7 +34,9 @@ public class U2G5ConfigurationScreen implements ConfigurationScreen {
 
 	@Override
 	public String getName(Locale locale) {
-		return "U2G5 Custom Configuration";
+		return LanguageUtil.get(
+			ResourceBundleUtil.getBundle(locale, U2G5ConfigurationScreen.class),
+			"u2g5-custom-configuration");
 	}
 
 	@Override

--- a/docs/dxp/latest/en/developing-applications/core-frameworks/configuration-framework/completely-custom-configuration/resources/liferay-u2g5.zip/u2g5-web/src/main/java/com/acme/u2g5/web/internal/configuration/admin/display/U2G5ConfigurationScreen.java
+++ b/docs/dxp/latest/en/developing-applications/core-frameworks/configuration-framework/completely-custom-configuration/resources/liferay-u2g5.zip/u2g5-web/src/main/java/com/acme/u2g5/web/internal/configuration/admin/display/U2G5ConfigurationScreen.java
@@ -29,14 +29,14 @@ public class U2G5ConfigurationScreen implements ConfigurationScreen {
 
 	@Override
 	public String getKey() {
-		return "u2g5-configuration-name";
+		return "u2g5-configuration";
 	}
 
 	@Override
 	public String getName(Locale locale) {
 		return LanguageUtil.get(
 			ResourceBundleUtil.getBundle(locale, U2G5ConfigurationScreen.class),
-			"u2g5-custom-configuration");
+			"u2g5-configuration");
 	}
 
 	@Override

--- a/docs/dxp/latest/en/developing-applications/core-frameworks/configuration-framework/completely-custom-configuration/resources/liferay-u2g5.zip/u2g5-web/src/main/java/com/acme/u2g5/web/internal/configuration/admin/display/U2G5ConfigurationScreen.java
+++ b/docs/dxp/latest/en/developing-applications/core-frameworks/configuration-framework/completely-custom-configuration/resources/liferay-u2g5.zip/u2g5-web/src/main/java/com/acme/u2g5/web/internal/configuration/admin/display/U2G5ConfigurationScreen.java
@@ -62,7 +62,7 @@ public class U2G5ConfigurationScreen implements ConfigurationScreen {
 			requestDispatcher.include(httpServletRequest, httpServletResponse);
 		}
 		catch (Exception exception) {
-			throw new IOException("Unable to render", exception);
+			throw new IOException("Unable to render /u2g5.jsp", exception);
 		}
 	}
 

--- a/docs/dxp/latest/en/developing-applications/core-frameworks/configuration-framework/completely-custom-configuration/resources/liferay-u2g5.zip/u2g5-web/src/main/java/com/acme/u2g5/web/internal/settings/definition/U2G5WebConfigurationBeanDeclaration.java
+++ b/docs/dxp/latest/en/developing-applications/core-frameworks/configuration-framework/completely-custom-configuration/resources/liferay-u2g5.zip/u2g5-web/src/main/java/com/acme/u2g5/web/internal/settings/definition/U2G5WebConfigurationBeanDeclaration.java
@@ -1,0 +1,18 @@
+package com.acme.u2g5.web.internal.settings.definition;
+
+import com.acme.u2g5.web.internal.configuration.U2G5WebConfiguration;
+
+import com.liferay.portal.kernel.settings.definition.ConfigurationBeanDeclaration;
+
+import org.osgi.service.component.annotations.Component;
+
+@Component(service = ConfigurationBeanDeclaration.class)
+public class U2G5WebConfigurationBeanDeclaration
+	implements ConfigurationBeanDeclaration {
+
+	@Override
+	public Class<?> getConfigurationBeanClass() {
+		return U2G5WebConfiguration.class;
+	}
+
+}

--- a/docs/dxp/latest/en/developing-applications/core-frameworks/configuration-framework/completely-custom-configuration/resources/liferay-u2g5.zip/u2g5-web/src/main/resources/META-INF/resources/u2g5.jsp
+++ b/docs/dxp/latest/en/developing-applications/core-frameworks/configuration-framework/completely-custom-configuration/resources/liferay-u2g5.zip/u2g5-web/src/main/resources/META-INF/resources/u2g5.jsp
@@ -1,0 +1,18 @@
+<%@ taglib uri="http://java.sun.com/portlet_2_0" prefix="portlet" %>
+
+<%@ page import="com.acme.u2g5.web.internal.configuration.U2G5WebConfiguration" %>
+
+<h4>U2G5 Custom Configuration</h4>
+
+<%
+U2G5WebConfiguration u2g5WebConfiguration = (U2G5WebConfiguration)request.getAttribute(U2G5WebConfiguration.class.getName());
+%>
+
+<p
+	style="color: <%= u2g5WebConfiguration.fontColor() %>; font-family: <%= u2g5WebConfiguration.fontFamily() %>; font-size: <%= u2g5WebConfiguration.fontSize() %>pt;"
+>
+	<liferay-ui:message key="u2g5-custom-configuration" /><br />
+	color: <%= u2g5WebConfiguration.fontColor() %><br />
+	font-family: <%= u2g5WebConfiguration.fontFamily() %><br />
+	font-size: <%= u2g5WebConfiguration.fontSize() %>
+</p>

--- a/docs/dxp/latest/en/developing-applications/core-frameworks/configuration-framework/completely-custom-configuration/resources/liferay-u2g5.zip/u2g5-web/src/main/resources/META-INF/resources/u2g5.jsp
+++ b/docs/dxp/latest/en/developing-applications/core-frameworks/configuration-framework/completely-custom-configuration/resources/liferay-u2g5.zip/u2g5-web/src/main/resources/META-INF/resources/u2g5.jsp
@@ -11,7 +11,7 @@ U2G5WebConfiguration u2g5WebConfiguration = (U2G5WebConfiguration)request.getAtt
 <p
 	style="color: <%= u2g5WebConfiguration.fontColor() %>; font-family: <%= u2g5WebConfiguration.fontFamily() %>; font-size: <%= u2g5WebConfiguration.fontSize() %>pt;"
 >
-	<liferay-ui:message key="u2g5-custom-configuration" /><br />
+	<liferay-ui:message key="u2g5-configuration" /><br />
 	color: <%= u2g5WebConfiguration.fontColor() %><br />
 	font-family: <%= u2g5WebConfiguration.fontFamily() %><br />
 	font-size: <%= u2g5WebConfiguration.fontSize() %>

--- a/docs/dxp/latest/en/developing-applications/core-frameworks/configuration-framework/completely-custom-configuration/resources/liferay-u2g5.zip/u2g5-web/src/main/resources/content/Language.properties
+++ b/docs/dxp/latest/en/developing-applications/core-frameworks/configuration-framework/completely-custom-configuration/resources/liferay-u2g5.zip/u2g5-web/src/main/resources/content/Language.properties
@@ -1,0 +1,2 @@
+u2g5-configuration-name=U2G5 Configuration
+u2g5-custom-configuration=U2G5 Custom Configuration

--- a/docs/dxp/latest/en/developing-applications/core-frameworks/configuration-framework/completely-custom-configuration/resources/liferay-u2g5.zip/u2g5-web/src/main/resources/content/Language.properties
+++ b/docs/dxp/latest/en/developing-applications/core-frameworks/configuration-framework/completely-custom-configuration/resources/liferay-u2g5.zip/u2g5-web/src/main/resources/content/Language.properties
@@ -1,2 +1,1 @@
-u2g5-configuration-name=U2G5 Configuration
-u2g5-custom-configuration=U2G5 Custom Configuration
+u2g5-configuration=U2G5 Configuration


### PR DESCRIPTION
Per @mtokudome

> https://issues.liferay.com/browse/LRDOCS-9534

> After deploying the code, navigate to System Settings > Third Party to see the custom configuration.

> The code shows a simple example of how the JSP file is accessing the configuration object with the use of ConfigurationScreen. But a developer could continue to build out a fully customized configuration UI as they see fit.